### PR TITLE
Fix diagnosis key filtering & clean up interval calculation code

### DIFF
--- a/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyService.java
+++ b/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyService.java
@@ -24,8 +24,7 @@ public class DiagnosisKeyService {
 
     private static final Logger LOG = LoggerFactory.getLogger(DiagnosisKeyService.class);
 
-    // 14-1 since the age is measured in full days and fractions get cropped
-    private static final Duration MAX_KEY_AGE = Duration.ofDays(13);
+    private static final Duration MAX_KEY_AGE = Duration.ofDays(14);
 
     private final DiagnosisKeyDao dao;
     private final PublishTokenVerificationService tokenVerificationService;
@@ -67,7 +66,7 @@ public class DiagnosisKeyService {
 
     List<TemporaryExposureKey> filter(List<TemporaryExposureKey> original, Instant now) {
         int minInterval = dayFirst10MinInterval(now.minus(MAX_KEY_AGE));
-        int maxInterval = to10MinInterval(now);
+        int maxInterval = dayLast10MinInterval(now);
         return original.stream().filter(key -> isBetween(key, minInterval, maxInterval)).collect(Collectors.toList());
     }
 

--- a/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/diagnosiskey/IntervalNumber.java
+++ b/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/diagnosiskey/IntervalNumber.java
@@ -6,48 +6,11 @@ import java.time.ZoneOffset;
 
 public final class IntervalNumber {
 
-    public static final int SECONDS_PER_24H = 60*60*24;
-    public static final int SECONDS_PER_10MIN = 60*10;
-    public static final int INTERVALS_10MIN_PER_24H = 6*24;
-    public static final Instant MAX_REPRESENTABLE_INSTANT =
-            Instant.ofEpochSecond(Integer.MAX_VALUE * SECONDS_PER_10MIN);
+    private IntervalNumber() {}
 
-    public final Instant instant;
-
-    private IntervalNumber(Instant instant) {
-        if (instant.isAfter(MAX_REPRESENTABLE_INSTANT)) {
-            throw new IllegalStateException("Cannot represent time with int interval number: instant=" + instant);
-        }
-        this.instant = instant;
-    }
-
-    public static IntervalNumber now() {
-        return ofInstant(Instant.now());
-    }
-
-    public static IntervalNumber ofInstant(Instant instant) {
-        return new IntervalNumber(instant);
-    }
-
-    public static IntervalNumber of24hNumber(int number) {
-        return new IntervalNumber(startMomentOf24HourInterval(number));
-    }
-
-    public static IntervalNumber of10minNumber(int number) {
-        return new IntervalNumber(startMomentOf10MinInterval(number));
-    }
-
-    public IntervalNumber atStartOfDate() {
-        return of24hNumber(get24HourInterval());
-    }
-
-    public Instant getInstant() {
-        return instant;
-    }
-
-    public int get24HourInterval() {
-        return to24HourInterval(instant);
-    }
+    public static final int SECONDS_PER_24H = 60 * 60 * 24;
+    public static final int SECONDS_PER_10MIN = 60 * 10;
+    public static final int INTERVALS_10MIN_PER_24H = 6 * 24;
 
     public static int to24HourInterval(Instant time) {
         long value = time.getEpochSecond() / SECONDS_PER_24H;
@@ -66,22 +29,21 @@ public final class IntervalNumber {
     }
 
     public static int dayFirst10MinInterval(Instant time) {
-        return to10MinInterval(startMomentOf24HourInterval(to24HourInterval(time)));
+        int dayNumber = to24HourInterval(time);
+        return dayNumber * INTERVALS_10MIN_PER_24H;
+    }
+
+    public static int dayLast10MinInterval(Instant time) {
+        int nextDayNumber = to24HourInterval(time) + 1;
+        return nextDayNumber * INTERVALS_10MIN_PER_24H - 1;
     }
 
     public static long startSecondOf24HourInterval(int interval24h) {
         return interval24h * SECONDS_PER_24H;
     }
 
-    private static Instant startMomentOf24HourInterval(int interval) {
-        return Instant.ofEpochSecond(SECONDS_PER_24H*interval);
-    }
-
-    private static Instant startMomentOf10MinInterval(int interval) {
-        return Instant.ofEpochSecond(SECONDS_PER_10MIN*interval);
-    }
-
     public static LocalDate utcDateOf10MinInterval(int interval) {
-        return startMomentOf10MinInterval(interval).atOffset(ZoneOffset.UTC).toLocalDate();
+        Instant startMoment = Instant.ofEpochSecond(SECONDS_PER_10MIN * interval);
+        return startMoment.atOffset(ZoneOffset.UTC).toLocalDate();
     }
 }

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyServiceTest.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyServiceTest.java
@@ -2,7 +2,6 @@ package fi.thl.covid19.exposurenotification.diagnosiskey;
 
 import fi.thl.covid19.exposurenotification.diagnosiskey.v1.TemporaryExposureKey;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +15,7 @@ import java.util.List;
 
 import static fi.thl.covid19.exposurenotification.diagnosiskey.IntervalNumber.to10MinInterval;
 import static java.time.ZoneOffset.UTC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ActiveProfiles({"test", "nodb"})
@@ -36,6 +36,7 @@ public class DiagnosisKeyServiceTest {
     @Test
     public void filterAcceptsKeyInsideRange() {
         List<TemporaryExposureKey> keys = List.of(
+                generateAt(LocalDate.parse("2020-07-02")),
                 generateAt(LocalDate.parse("2020-07-03")),
                 generateAt(LocalDate.parse("2020-07-04")),
                 generateAt(LocalDate.parse("2020-07-05")),
@@ -49,25 +50,27 @@ public class DiagnosisKeyServiceTest {
                 generateAt(LocalDate.parse("2020-07-13")),
                 generateAt(LocalDate.parse("2020-07-14")),
                 generateAt(LocalDate.parse("2020-07-15")));
-        Assertions.assertEquals(keys, filter(keys, "2020-07-16T14:00:00Z"));
+        assertEquals(keys, filter(keys, "2020-07-16T14:00:00Z"));
+    }
+
+    @Test
+    public void filterAcceptsTodaysKeys() {
+        List<TemporaryExposureKey> keys = List.of(
+                generateAt(LocalDate.parse("2020-07-16"), 14*6),
+                generateAt(LocalDate.parse("2020-07-16"), 144));
+        assertEquals(keys, filter(keys, "2020-07-16T14:00:00Z"));
     }
 
     @Test
     public void filterRejectsOver14daysOldKey() {
-        List<TemporaryExposureKey> keys = List.of(generateAt(LocalDate.parse("2020-07-02")));
-        Assertions.assertEquals(List.of(), filter(keys, "2020-07-16T14:00:00Z"));
-    }
-
-    @Test
-    public void filterRejectsKeyOverlappingEnd() {
-        List<TemporaryExposureKey> keys = List.of(generateAt(LocalDate.parse("2020-07-16")));
-        Assertions.assertEquals(List.of(), filter(keys, "2020-07-16T14:00:00Z"));
+        List<TemporaryExposureKey> keys = List.of(generateAt(LocalDate.parse("2020-07-01")));
+        assertEquals(List.of(), filter(keys, "2020-07-16T14:00:00Z"));
     }
 
     @Test
     public void filterRejectsKeyInFuture() {
         List<TemporaryExposureKey> keys = List.of(generateAt(LocalDate.parse("2020-07-17")));
-        Assertions.assertEquals(List.of(), filter(keys, "2020-07-16T14:00:00Z"));
+        assertEquals(List.of(), filter(keys, "2020-07-16T14:00:00Z"));
     }
 
     private List<TemporaryExposureKey> filter(List<TemporaryExposureKey> keys, String now) {
@@ -75,7 +78,11 @@ public class DiagnosisKeyServiceTest {
     }
 
     private TemporaryExposureKey generateAt(LocalDate keyDate) {
+        return generateAt(keyDate, 144);
+    }
+
+    private TemporaryExposureKey generateAt(LocalDate keyDate, int rollingPeriod) {
         int interval = to10MinInterval(keyDate.atStartOfDay(UTC).toInstant());
-        return new TemporaryExposureKey("c9Uau9icuBlvDvtokvlNaA==", 1, interval, 144);
+        return new TemporaryExposureKey("c9Uau9icuBlvDvtokvlNaA==", 1, interval, rollingPeriod);
     }
 }


### PR DESCRIPTION
The filtering was unnecessarily strict due to confusion about the spec. After testing, it's evident that this should be sufficient.
Also fixed demo-mode filtering by allowing current-day keys even from older API-version which doesn't cut the periods.
Also cleaned up some old code from interval calculation