### PR TITLE
Make services runnable for open source developers:

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,49 @@ cd exposure-notification
 ```
 
 ## Database Migrations
-Each service handles their own schema (en for exposure-notification and pt for publish-token), migrating them via Flyway as needed. 
+Each service handles its own schema (en for exposure-notification and pt for publish-token), migrating them via Flyway as needed. 
 They don't cross-use each other's data so service update/startup order should not matter. If desired, the services can be configured not to even see each other's schemas. 
 
 In development environment, you may want to use the property `-Dspring.flyway.clean-on-validation-error=true`. 
 This allows you to edit the schema definitions freely and have flyway simply reset the database when you make an incompatible change.
-Obviously, you never want to deploy that setting into production environments though (as you will lose all data), so it's not on by default.
+Obviously, you never want to deploy that setting into production environments though, as you will lose all data.
+
+## Running Locally
+
+### Requirements
+Java 11
+PostgreSQL 12
+
+### Quick Startup
+- The easiest way to get postgresql for development is via docker, for instance (using [the official image in docker hub](https://hub.docker.com/_/postgres)):
+  ```
+  docker run \
+  --name covid19-db \
+  -p 127.0.0.1:5433:5432 \
+  -e POSTGRES_DB=exposure-notification \
+  -e POSTGRES_USER=devserver \
+  -e POSTGRES_PASSWORD=devserver-password \
+  postgres:12
+  ```
+  - You can set the database to store the files in a location of your choosing by adding the parameter
+    ```
+    -v my-local-db-dir:/var/lib/postgresql/data
+    ``` 
+  - If you vary the parameters (username/password/port), just update them for each service `src/resources/application-dev.yml`
+- Build both applications: `./mvnw clean package`
+- Start exposure-notification service
+    ```
+    cd exposure-notification
+    java \
+      -Dspring.profiles.active=dev \
+      -jar target/exposure-notification-1.0.0-SNAPSHOT.jar \
+      fi.thl.covid19.exposurenotification.ExposureNotificationApplication
+    ```
+- Start publish-token service
+    ```
+    cd publish-token
+    java \
+      -Dspring.profiles.active=dev \
+      -jar target/publish-token-1.0.0-SNAPSHOT.jar \
+      fi.thl.covid19.publishtoken.PublishTokenApplication
+    ```

--- a/exposure-notification/src/main/resources/application-dev.yml
+++ b/exposure-notification/src/main/resources/application-dev.yml
@@ -1,0 +1,17 @@
+logging:
+  config: src/main/resources/logback-dev.xml
+
+spring:
+  datasource:
+    url: "jdbc:postgresql://localhost:5433/exposure-notification"
+    username: "devserver"
+    password: "devserver-password"
+  flyway:
+    clean-on-validation-error: true
+
+covid19:
+  diagnosis:
+    signature:
+      randomize-key: true
+  publish-token:
+    url: "http://localhost:8081"

--- a/exposure-notification/src/main/resources/application.yml
+++ b/exposure-notification/src/main/resources/application.yml
@@ -52,9 +52,9 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
   flyway:
-    url: "${EN_DATABASE_URL}"
-    user: "${EN_DATABASE_USERNAME}"
-    password: "${EN_DATABASE_PASSWORD}"
+    url: "${spring.datasource.url}"
+    user: "${spring.datasource.username}"
+    password: "${spring.datasource.password}"
     schemas: en
 
 covid19:

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/batch/BatchFileServiceIT.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/batch/BatchFileServiceIT.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * NOTE: These tests require the DB to be available and configured through ENV.
  */
 @SpringBootTest
-@ActiveProfiles({"test"})
+@ActiveProfiles({"dev","test"})
 @AutoConfigureMockMvc
 public class BatchFileServiceIT {
 

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/configuration/ConfigurationControllerIT.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/configuration/ConfigurationControllerIT.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@ActiveProfiles({"test"})
+@ActiveProfiles({"dev","test"})
 @SpringBootTest
 @AutoConfigureMockMvc
 public class ConfigurationControllerIT {

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/configuration/ConfigurationDaoIT.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/configuration/ConfigurationDaoIT.java
@@ -9,11 +9,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * NOTE: These tests require the DB to be available and configured through ENV.
- */
 @SpringBootTest
-@ActiveProfiles({"test"})
+@ActiveProfiles({"dev","test"})
 @AutoConfigureMockMvc
 public class ConfigurationDaoIT {
 

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyControllerDemoIT.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyControllerDemoIT.java
@@ -31,11 +31,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.util.DigestUtils.md5DigestAsHex;
 
-/**
- * NOTE: These tests require the DB to be available and configured through ENV.
- */
 @SpringBootTest(properties = { "covid19.demo-mode=true" })
-@ActiveProfiles({"test"})
+@ActiveProfiles({"dev","test"})
 @AutoConfigureMockMvc
 public class DiagnosisKeyControllerDemoIT {
 

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyControllerIT.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyControllerIT.java
@@ -50,7 +50,7 @@ import static org.springframework.util.DigestUtils.md5DigestAsHex;
  * NOTE: These tests require the DB to be available and configured through ENV.
  */
 @SpringBootTest
-@ActiveProfiles({"test"})
+@ActiveProfiles({"dev","test"})
 @AutoConfigureMockMvc
 public class DiagnosisKeyControllerIT {
 

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyDaoIT.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyDaoIT.java
@@ -21,7 +21,7 @@ import static org.springframework.util.DigestUtils.md5DigestAsHex;
  * NOTE: These tests require the DB to be available and configured through ENV.
  */
 @SpringBootTest
-@ActiveProfiles({"test"})
+@ActiveProfiles({"dev","test"})
 @AutoConfigureMockMvc
 public class DiagnosisKeyDaoIT {
 

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyServiceTest.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyServiceTest.java
@@ -18,7 +18,7 @@ import static java.time.ZoneOffset.UTC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-@ActiveProfiles({"test", "nodb"})
+@ActiveProfiles({"dev","test","nodb"})
 @SpringBootTest
 public class DiagnosisKeyServiceTest {
 

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/error/ApiErrorHandlerTest.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/error/ApiErrorHandlerTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ActiveProfiles({"test", "nodb"})
+@ActiveProfiles({"dev","test","nodb"})
 @SpringBootTest
 @AutoConfigureMockMvc
 public class ApiErrorHandlerTest {

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/tokenverification/PublishTokenVerificationServiceRestTest.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/tokenverification/PublishTokenVerificationServiceRestTest.java
@@ -26,9 +26,10 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
 @SpringBootTest
-@ActiveProfiles({"test", "nodb"})
+@ActiveProfiles({"dev","test","nodb"})
 public class PublishTokenVerificationServiceRestTest {
 
+    private static final String VERIFICATION_URL = "http://localhost:8081" + TOKEN_VERIFICATION_PATH;
     @Autowired
     private PublishTokenVerificationServiceRest verificationService;
 
@@ -56,7 +57,7 @@ public class PublishTokenVerificationServiceRestTest {
     @Test
     public void verificationWorks() throws Exception {
         PublishTokenVerification response = new PublishTokenVerification(123, LocalDate.now());
-        server.expect(requestTo(TOKEN_VERIFICATION_PATH))
+        server.expect(requestTo(VERIFICATION_URL))
                 .andExpect(header(PUBLISH_TOKEN_HEADER, "123456789012"))
                 .andRespond(withSuccess(objectMapper.writeValueAsString(response), APPLICATION_JSON));
         PublishTokenVerification verification = verificationService.getVerification("123456789012");
@@ -67,7 +68,7 @@ public class PublishTokenVerificationServiceRestTest {
 
     @Test
     public void rejectionWorks() {
-        server.expect(requestTo(TOKEN_VERIFICATION_PATH))
+        server.expect(requestTo(VERIFICATION_URL))
                 .andExpect(header(PUBLISH_TOKEN_HEADER, "123456789012"))
                 .andRespond(withNoContent());
         assertThrows(TokenValidationException.class, () -> verificationService.getVerification("123456789012"));
@@ -76,7 +77,7 @@ public class PublishTokenVerificationServiceRestTest {
 
     @Test
     public void badRequestRejectsToken() {
-        server.expect(requestTo(TOKEN_VERIFICATION_PATH))
+        server.expect(requestTo(VERIFICATION_URL))
                 .andExpect(header(PUBLISH_TOKEN_HEADER, "123456789012"))
                 .andRespond(withBadRequest());
         assertThrows(TokenValidationException.class, () -> verificationService.getVerification("123456789012"));
@@ -85,7 +86,7 @@ public class PublishTokenVerificationServiceRestTest {
 
     @Test
     public void unauthorizedRequestRejectsToken() {
-        server.expect(requestTo(TOKEN_VERIFICATION_PATH))
+        server.expect(requestTo(VERIFICATION_URL))
                 .andExpect(header(PUBLISH_TOKEN_HEADER, "123456789012"))
                 .andRespond(withUnauthorizedRequest());
         assertThrows(TokenValidationException.class, () -> verificationService.getVerification("123456789012"));
@@ -94,7 +95,7 @@ public class PublishTokenVerificationServiceRestTest {
 
     @Test
     public void serverErrorLeadsToInternalError() {
-        server.expect(requestTo(TOKEN_VERIFICATION_PATH))
+        server.expect(requestTo(VERIFICATION_URL))
                 .andExpect(header(PUBLISH_TOKEN_HEADER, "123456789012"))
                 .andRespond(withServerError());
         assertThrows(IllegalStateException.class, () -> verificationService.getVerification("123456789012"));

--- a/exposure-notification/src/test/resources/application-test.yml
+++ b/exposure-notification/src/test/resources/application-test.yml
@@ -1,6 +1,4 @@
 covid19:
   diagnosis:
-    signature:
-      randomize-key: true
     data-cache:
       enabled: false

--- a/publish-token/src/main/resources/application-dev.yml
+++ b/publish-token/src/main/resources/application-dev.yml
@@ -1,0 +1,17 @@
+logging:
+  config: src/main/resources/logback-dev.xml
+
+server:
+  port: 8080
+
+management:
+  server:
+    port: 9081
+
+spring:
+  datasource:
+    url: "jdbc:postgresql://localhost:5433/exposure-notification"
+    username: "devserver"
+    password: "devserver-password"
+  flyway:
+    clean-on-validation-error: true

--- a/publish-token/src/main/resources/application.yml
+++ b/publish-token/src/main/resources/application.yml
@@ -48,9 +48,9 @@ spring:
       validation-timeout: 5000
       connection-test-query: SELECT 1
   flyway:
-    url: "${PT_DATABASE_URL}"
-    user: "${PT_DATABASE_USERNAME}"
-    password: "${PT_DATABASE_PASSWORD}"
+    url: "${spring.datasource.url}"
+    user: "${spring.datasource.username}"
+    password: "${spring.datasource.password}"
     schemas: pt
 
 covid19:

--- a/publish-token/src/test/java/fi/thl/covid19/publishtoken/PublishTokenDaoIT.java
+++ b/publish-token/src/test/java/fi/thl/covid19/publishtoken/PublishTokenDaoIT.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -18,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
+@ActiveProfiles({"dev"})
 @AutoConfigureMockMvc
 public class PublishTokenDaoIT {
 

--- a/publish-token/src/test/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationControllerIT.java
+++ b/publish-token/src/test/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationControllerIT.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(properties = {"covid19.publish-token.validity-duration=PT10M"})
+@ActiveProfiles({"dev"})
 @AutoConfigureMockMvc
 public class PublishTokenGenerationControllerIT {
 

--- a/publish-token/src/test/java/fi/thl/covid19/publishtoken/verification/v1/PublishTokenVerificationControllerIT.java
+++ b/publish-token/src/test/java/fi/thl/covid19/publishtoken/verification/v1/PublishTokenVerificationControllerIT.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Instant;
@@ -22,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@ActiveProfiles({"dev"})
 @AutoConfigureMockMvc
 public class PublishTokenVerificationControllerIT {
 


### PR DESCRIPTION
- Update README with some getting started instructions
- Add a dev-profile for running the services without ENV trickery
- Make tests run on dev-profile, so they don't need ENV trickery either