### PR TITLE
Allow validateOnly to be provided in header on V1 publishToken api

### DIFF
--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/Validation.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/Validation.java
@@ -1,6 +1,12 @@
 package fi.thl.covid19.publishtoken;
 
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.thl.covid19.publishtoken.error.InputValidationException;
+import fi.thl.covid19.publishtoken.error.InputValidationValidateOnlyException;
+import fi.thl.covid19.publishtoken.generation.v1.PublishTokenGenerationRequest;
+
+import java.io.IOException;
 
 public final class Validation {
     private Validation() {
@@ -14,6 +20,20 @@ public final class Validation {
     public static final int USER_NAME_MAX_LENGTH = 50;
     public static final int SERVICE_NAME_MAX_LENGTH = 100;
     private static final String NAME_REGEX = "([A-Za-z0-9\\-_.]+)";
+
+
+    public static PublishTokenGenerationRequest validateAndCreate(String jsonBody, boolean validateOnly, ObjectMapper om) {
+        InjectableValues injectableValues = new InjectableValues.Std().addValue(boolean.class, validateOnly);
+        try {
+            return om.reader(injectableValues).readValue(jsonBody, PublishTokenGenerationRequest.class);
+        } catch (IOException e) {
+            if (validateOnly) {
+                throw new InputValidationValidateOnlyException("ValidateOnly: " + e.getMessage());
+            } else {
+                throw new InputValidationException(e.getMessage());
+            }
+        }
+    }
 
     public static String validatePublishToken(String publishToken) {
         if (!publishToken.matches(TOKEN_REGEX)) {

--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/Validation.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/Validation.java
@@ -1,12 +1,7 @@
 package fi.thl.covid19.publishtoken;
 
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.thl.covid19.publishtoken.error.InputValidationException;
-import fi.thl.covid19.publishtoken.error.InputValidationValidateOnlyException;
-import fi.thl.covid19.publishtoken.generation.v1.PublishTokenGenerationRequest;
-
-import java.io.IOException;
+import org.springframework.web.context.request.NativeWebRequest;
 
 public final class Validation {
     private Validation() {
@@ -22,17 +17,8 @@ public final class Validation {
     private static final String NAME_REGEX = "([A-Za-z0-9\\-_.]+)";
 
 
-    public static PublishTokenGenerationRequest validateAndCreate(String jsonBody, boolean validateOnly, ObjectMapper om) {
-        InjectableValues injectableValues = new InjectableValues.Std().addValue(boolean.class, validateOnly);
-        try {
-            return om.reader(injectableValues).readValue(jsonBody, PublishTokenGenerationRequest.class);
-        } catch (IOException e) {
-            if (validateOnly) {
-                throw new InputValidationValidateOnlyException("ValidateOnly: " + e.getMessage());
-            } else {
-                throw new InputValidationException(e.getMessage());
-            }
-        }
+    public static boolean validateBooleanHeader(NativeWebRequest nativeWebRequest, String headerName) {
+       return Boolean.parseBoolean(nativeWebRequest.getHeader(headerName));
     }
 
     public static String validatePublishToken(String publishToken) {

--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/WebMvcConfiguration.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/WebMvcConfiguration.java
@@ -1,21 +1,35 @@
 package fi.thl.covid19.publishtoken;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.thl.covid19.publishtoken.error.CorrelationIdInterceptor;
+import fi.thl.covid19.publishtoken.generation.v1.PublishTokenGenerationRequestArgumentResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
-    final CorrelationIdInterceptor correlationIdInterceptor;
+    private final CorrelationIdInterceptor correlationIdInterceptor;
+    private final ObjectMapper jacksonObjectMapper;
 
-    public WebMvcConfiguration(CorrelationIdInterceptor correlationIdInterceptor) {
+    public WebMvcConfiguration(CorrelationIdInterceptor correlationIdInterceptor,
+                               ObjectMapper jacksonObjectMapper) {
         this.correlationIdInterceptor = correlationIdInterceptor;
+        this.jacksonObjectMapper = jacksonObjectMapper;
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(correlationIdInterceptor);
+    }
+
+    @Override
+    public void addArgumentResolvers(
+            List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(new PublishTokenGenerationRequestArgumentResolver(jacksonObjectMapper));
     }
 }

--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationController.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationController.java
@@ -1,6 +1,5 @@
 package fi.thl.covid19.publishtoken.generation.v1;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.thl.covid19.publishtoken.PublishTokenService;
 import fi.thl.covid19.publishtoken.sms.SmsService;
 import fi.thl.covid19.publishtoken.Validation;
@@ -19,26 +18,20 @@ public class PublishTokenGenerationController {
     private static final Logger LOG = LoggerFactory.getLogger(PublishTokenGenerationController.class);
 
     public static final String SERVICE_NAME_HEADER = "KV-Request-Service";
-    public static final String VALIDATE_ONLY_HEADER = "X-Validate-Only";
 
     private final PublishTokenService publishTokenService;
     private final SmsService smsService;
-    private final ObjectMapper jacksonObjectMapper;
 
     public PublishTokenGenerationController(PublishTokenService publishTokenService,
-                                            SmsService smsService,
-                                            ObjectMapper jacksonObjectMapper) {
+                                            SmsService smsService) {
         this.publishTokenService = requireNonNull(publishTokenService);
         this.smsService = requireNonNull(smsService);
-        this.jacksonObjectMapper = jacksonObjectMapper;
     }
 
     @PostMapping
     public PublishToken generateToken(@RequestHeader(name = SERVICE_NAME_HEADER) String rawRequestService,
-                                      @RequestHeader(name = VALIDATE_ONLY_HEADER, required = false) boolean validateOnlyHeader,
-                                      @RequestBody String requestBody) {
+                                      @PublishTokenGenerationData PublishTokenGenerationRequest request) {
         String requestService = Validation.validateServiceName(rawRequestService);
-        PublishTokenGenerationRequest request = Validation.validateAndCreate(requestBody, validateOnlyHeader, jacksonObjectMapper);
         if (request.validateOnly) {
             LOG.debug("API Validation Test: Generate new publish token: {} {}",
                     keyValue("service", requestService), keyValue("user", request.requestUser));

--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationController.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationController.java
@@ -1,5 +1,6 @@
 package fi.thl.covid19.publishtoken.generation.v1;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.thl.covid19.publishtoken.PublishTokenService;
 import fi.thl.covid19.publishtoken.sms.SmsService;
 import fi.thl.covid19.publishtoken.Validation;
@@ -18,19 +19,26 @@ public class PublishTokenGenerationController {
     private static final Logger LOG = LoggerFactory.getLogger(PublishTokenGenerationController.class);
 
     public static final String SERVICE_NAME_HEADER = "KV-Request-Service";
+    public static final String VALIDATE_ONLY_HEADER = "X-Validate-Only";
 
     private final PublishTokenService publishTokenService;
     private final SmsService smsService;
+    private final ObjectMapper jacksonObjectMapper;
 
-    public PublishTokenGenerationController(PublishTokenService publishTokenService, SmsService smsService) {
+    public PublishTokenGenerationController(PublishTokenService publishTokenService,
+                                            SmsService smsService,
+                                            ObjectMapper jacksonObjectMapper) {
         this.publishTokenService = requireNonNull(publishTokenService);
         this.smsService = requireNonNull(smsService);
+        this.jacksonObjectMapper = jacksonObjectMapper;
     }
 
     @PostMapping
-    public PublishToken generateToken(@RequestHeader(name = SERVICE_NAME_HEADER) String rawRequestService, @RequestBody PublishTokenGenerationRequest request) {
+    public PublishToken generateToken(@RequestHeader(name = SERVICE_NAME_HEADER) String rawRequestService,
+                                      @RequestHeader(name = VALIDATE_ONLY_HEADER, required = false) boolean validateOnlyHeader,
+                                      @RequestBody String requestBody) {
         String requestService = Validation.validateServiceName(rawRequestService);
-
+        PublishTokenGenerationRequest request = Validation.validateAndCreate(requestBody, validateOnlyHeader, jacksonObjectMapper);
         if (request.validateOnly) {
             LOG.debug("API Validation Test: Generate new publish token: {} {}",
                     keyValue("service", requestService), keyValue("user", request.requestUser));

--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationData.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationData.java
@@ -1,0 +1,11 @@
+package fi.thl.covid19.publishtoken.generation.v1;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface PublishTokenGenerationData {
+}

--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationRequest.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationRequest.java
@@ -1,5 +1,6 @@
 package fi.thl.covid19.publishtoken.generation.v1;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import fi.thl.covid19.publishtoken.Validation;
 import fi.thl.covid19.publishtoken.error.InputValidationException;
@@ -23,9 +24,10 @@ public class PublishTokenGenerationRequest {
     public PublishTokenGenerationRequest(String requestUser,
                                          LocalDate symptomsOnset,
                                          Optional<String> patientSmsNumber,
-                                         Optional<Boolean> validateOnly) {
+                                         Optional<Boolean> validateOnly,
+                                         @JacksonInject boolean validateOnlyHeader) {
 
-        this.validateOnly = validateOnly.orElse(false);
+        this.validateOnly = validateOnlyHeader || validateOnly.orElse(false);
 
         try {
             this.requestUser = validateUserName(requireNonNull(requestUser, "User required"));

--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationRequestArgumentResolver.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationRequestArgumentResolver.java
@@ -1,0 +1,60 @@
+package fi.thl.covid19.publishtoken.generation.v1;
+
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.thl.covid19.publishtoken.Validation;
+import fi.thl.covid19.publishtoken.error.InputValidationException;
+import fi.thl.covid19.publishtoken.error.InputValidationValidateOnlyException;
+import org.springframework.core.MethodParameter;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public class PublishTokenGenerationRequestArgumentResolver implements HandlerMethodArgumentResolver {
+
+    public static final String VALIDATE_ONLY_HEADER = "X-Validate-Only";
+
+    private final ObjectMapper jacksonObjectMapper;
+
+    public PublishTokenGenerationRequestArgumentResolver(ObjectMapper jacksonObjectMapper) {
+        this.jacksonObjectMapper = jacksonObjectMapper;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter methodParameter) {
+        return methodParameter.getParameterAnnotation(PublishTokenGenerationData.class) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter methodParameter,
+                                  ModelAndViewContainer modelAndViewContainer,
+                                  NativeWebRequest nativeWebRequest,
+                                  WebDataBinderFactory webDataBinderFactory) throws Exception {
+        boolean validateOnly = Validation.validateBooleanHeader(nativeWebRequest, VALIDATE_ONLY_HEADER);
+        HttpServletRequest request = nativeWebRequest.getNativeRequest(HttpServletRequest.class);
+
+        if (request != null) {
+            return validateAndCreate(FileCopyUtils.copyToString(request.getReader()), validateOnly);
+        } else {
+            throw new NullPointerException("Request is null");
+        }
+    }
+
+    private PublishTokenGenerationRequest validateAndCreate(String body, boolean validateOnly) {
+        InjectableValues injectableValues = new InjectableValues.Std().addValue(boolean.class, validateOnly);
+        try {
+            return jacksonObjectMapper.reader(injectableValues).readValue(body, PublishTokenGenerationRequest.class);
+        } catch (IOException e) {
+            if (validateOnly) {
+                throw new InputValidationValidateOnlyException("ValidateOnly: " + e.getMessage());
+            } else {
+                throw new InputValidationException(e.getMessage());
+            }
+        }
+    }
+}

--- a/publish-token/src/test/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationControllerIT.java
+++ b/publish-token/src/test/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationControllerIT.java
@@ -57,7 +57,7 @@ public class PublishTokenGenerationControllerIT {
         Instant start = Instant.now().truncatedTo(SECONDS);
         LocalDate symptomsOnset = LocalDate.now().minus(1, DAYS);
         PublishTokenGenerationRequest request = new PublishTokenGenerationRequest(
-                TEST_USER, symptomsOnset, Optional.empty(), Optional.empty());
+                TEST_USER, symptomsOnset, Optional.empty(), Optional.empty(), false);
 
         PublishToken generated = verifiedPost(request);
         Instant end = Instant.now().truncatedTo(SECONDS).plus(1, SECONDS);
@@ -77,15 +77,21 @@ public class PublishTokenGenerationControllerIT {
         assertTokens(TEST_SERVICE, TEST_USER, List.of());
 
         PublishTokenGenerationRequest request1 = new PublishTokenGenerationRequest(
-                TEST_USER, LocalDate.now().minus(1, DAYS), Optional.empty(), Optional.empty());
+                TEST_USER, LocalDate.now().minus(1, DAYS), Optional.empty(), Optional.empty(), false);
         PublishTokenGenerationRequest request2 = new PublishTokenGenerationRequest(
-                TEST_USER, LocalDate.now().minus(1, DAYS), Optional.empty(), Optional.of(false));
+                TEST_USER, LocalDate.now().minus(1, DAYS), Optional.empty(), Optional.of(false), false);
         PublishTokenGenerationRequest request3 = new PublishTokenGenerationRequest(
-                TEST_USER, LocalDate.now().minus(1, DAYS), Optional.empty(), Optional.of(true));
+                TEST_USER, LocalDate.now().minus(1, DAYS), Optional.empty(), Optional.of(true), false);
+        PublishTokenGenerationRequest request4 = new PublishTokenGenerationRequest(
+                TEST_USER, LocalDate.now().minus(1, DAYS), Optional.empty(), Optional.empty(), true);
+        PublishTokenGenerationRequest request5 = new PublishTokenGenerationRequest(
+                TEST_USER, LocalDate.now().minus(1, DAYS), Optional.empty(), Optional.of(false), true);
 
         PublishToken generated1 = verifiedPost(request1);
         PublishToken generated2 = verifiedPost(request2);
         PublishToken generated3 = verifiedPost(request3);
+        verifiedPost(request4);
+        verifiedPost(request5);
 
         assertNotEquals(generated1.token, generated2.token);
         assertNotEquals(generated1.token, generated3.token);


### PR DESCRIPTION
Opened this for discussion.

Resolves: COVID-403