### PR TITLE
Allow validateOnly to be provided in header on V1 publishToken API, alternative

### DIFF
--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/error/InputValidationValidateOnlyException.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/error/InputValidationValidateOnlyException.java
@@ -1,5 +1,6 @@
 package fi.thl.covid19.publishtoken.error;
 
+@Deprecated
 public class InputValidationValidateOnlyException extends RuntimeException {
     public InputValidationValidateOnlyException(String msg) {
         super(msg);

--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationController.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationController.java
@@ -1,11 +1,13 @@
 package fi.thl.covid19.publishtoken.generation.v1;
 
 import fi.thl.covid19.publishtoken.PublishTokenService;
-import fi.thl.covid19.publishtoken.sms.SmsService;
 import fi.thl.covid19.publishtoken.Validation;
+import fi.thl.covid19.publishtoken.sms.SmsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 import static fi.thl.covid19.publishtoken.Validation.validateUserName;
 import static java.util.Objects.requireNonNull;
@@ -18,6 +20,7 @@ public class PublishTokenGenerationController {
     private static final Logger LOG = LoggerFactory.getLogger(PublishTokenGenerationController.class);
 
     public static final String SERVICE_NAME_HEADER = "KV-Request-Service";
+    public static final String VALIDATE_ONLY_HEADER = "KV-Validate-Only";
 
     private final PublishTokenService publishTokenService;
     private final SmsService smsService;
@@ -28,10 +31,12 @@ public class PublishTokenGenerationController {
     }
 
     @PostMapping
-    public PublishToken generateToken(@RequestHeader(name = SERVICE_NAME_HEADER) String rawRequestService, @RequestBody PublishTokenGenerationRequest request) {
+    public PublishToken generateToken(@RequestHeader(name = SERVICE_NAME_HEADER) String rawRequestService,
+                                      @RequestHeader(name = VALIDATE_ONLY_HEADER) Optional<Boolean> validateOnly,
+                                      @RequestBody PublishTokenGenerationRequest request) {
         String requestService = Validation.validateServiceName(rawRequestService);
 
-        if (request.validateOnly) {
+        if (validateOnly.orElse(request.validateOnly)) {
             LOG.debug("API Validation Test: Generate new publish token: {} {}",
                     keyValue("service", requestService), keyValue("user", request.requestUser));
             return publishTokenService.generate();

--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationController.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationController.java
@@ -7,8 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Optional;
-
 import static fi.thl.covid19.publishtoken.Validation.validateUserName;
 import static java.util.Objects.requireNonNull;
 import static net.logstash.logback.argument.StructuredArguments.keyValue;
@@ -32,11 +30,11 @@ public class PublishTokenGenerationController {
 
     @PostMapping
     public PublishToken generateToken(@RequestHeader(name = SERVICE_NAME_HEADER) String rawRequestService,
-                                      @RequestHeader(name = VALIDATE_ONLY_HEADER) Optional<Boolean> validateOnly,
+                                      @RequestHeader(name = VALIDATE_ONLY_HEADER, required = false) boolean validateOnly,
                                       @RequestBody PublishTokenGenerationRequest request) {
         String requestService = Validation.validateServiceName(rawRequestService);
 
-        if (validateOnly.orElse(request.validateOnly)) {
+        if (validateOnly || request.validateOnly) {
             LOG.debug("API Validation Test: Generate new publish token: {} {}",
                     keyValue("service", requestService), keyValue("user", request.requestUser));
             return publishTokenService.generate();

--- a/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationRequest.java
+++ b/publish-token/src/main/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationRequest.java
@@ -17,6 +17,7 @@ public class PublishTokenGenerationRequest {
     public final String requestUser;
     public final LocalDate symptomsOnset;
     public final Optional<String> patientSmsNumber;
+    @Deprecated
     public final boolean validateOnly;
 
     @JsonCreator

--- a/publish-token/src/test/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationControllerIT.java
+++ b/publish-token/src/test/java/fi/thl/covid19/publishtoken/generation/v1/PublishTokenGenerationControllerIT.java
@@ -100,7 +100,6 @@ public class PublishTokenGenerationControllerIT {
     public void validateOnlyHeaderDoesntGenerateToken() throws Exception {
         assertTokens(TEST_SERVICE, TEST_USER, List.of());
 
-        // The header overrides the json field
         PublishTokenGenerationRequest request1 = new PublishTokenGenerationRequest(
                 TEST_USER, LocalDate.now().minus(1, DAYS), Optional.empty(), Optional.empty());
         PublishTokenGenerationRequest request2 = new PublishTokenGenerationRequest(
@@ -116,12 +115,13 @@ public class PublishTokenGenerationControllerIT {
 
         PublishToken validateOnly1 = verifiedValidateOnlyPost(request1, true);
         PublishToken validateOnly2 = verifiedValidateOnlyPost(request2, true);
+        // Setting header to false works like no header -> uses the field
         PublishToken validateOnly3 = verifiedValidateOnlyPost(request3, false);
         assertNotEquals(generated1.token, validateOnly1.token);
         assertNotEquals(generated2.token, validateOnly2.token);
         assertNotEquals(generated3.token, validateOnly3.token);
-        // Validate-only header overrides the request value -> generate only the third one
-        assertTokens(TEST_SERVICE, TEST_USER, List.of(generated1, generated2, validateOnly3));
+        // All set to validateOnly -> Generate nothing new
+        assertTokens(TEST_SERVICE, TEST_USER, List.of(generated1, generated2));
     }
 
     @Test


### PR DESCRIPTION
Alternative way of providing the backwards compatible validateonly header, not injecting it into the request object.

Resolves: COVID-403