### PR TITLE
Fix potential interval number muplications overflow

### DIFF
--- a/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/diagnosiskey/IntervalNumber.java
+++ b/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/diagnosiskey/IntervalNumber.java
@@ -39,11 +39,11 @@ public final class IntervalNumber {
     }
 
     public static long startSecondOf24HourInterval(int interval24h) {
-        return interval24h * SECONDS_PER_24H;
+        return (long) interval24h * SECONDS_PER_24H;
     }
 
     public static LocalDate utcDateOf10MinInterval(int interval) {
-        Instant startMoment = Instant.ofEpochSecond(SECONDS_PER_10MIN * interval);
+        Instant startMoment = Instant.ofEpochSecond((long) interval * SECONDS_PER_10MIN);
         return startMoment.atOffset(ZoneOffset.UTC).toLocalDate();
     }
 }

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/IntervalNumberTest.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/IntervalNumberTest.java
@@ -1,0 +1,57 @@
+package fi.thl.covid19.exposurenotification.diagnosiskey;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static fi.thl.covid19.exposurenotification.diagnosiskey.IntervalNumber.*;
+import static java.time.ZoneOffset.UTC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IntervalNumberTest {
+
+    // Max moment representable via 10 min integer interval number (as is done by GAEN API)
+    private static final Instant MAX_SUPPORTED_TIME = Instant.ofEpochSecond(60L*10L*Integer.MAX_VALUE);
+
+    @Test
+    public void getting24hIntervalWorks() {
+        assertEquals(0, to24HourInterval(Instant.EPOCH));
+        assertEquals(20, to24HourInterval(Instant.parse("1970-01-21T12:00:00Z")));
+        assertEquals(Integer.MAX_VALUE/(6*24), to24HourInterval(MAX_SUPPORTED_TIME));
+    }
+
+    @Test
+    public void getting10MinIntervalWorks() {
+        assertEquals(0, to10MinInterval(Instant.EPOCH));
+        assertEquals(2943, to10MinInterval(Instant.parse("1970-01-21T10:30:00Z")));
+        assertEquals(Integer.MAX_VALUE, to10MinInterval(MAX_SUPPORTED_TIME));
+    }
+
+    @Test
+    public void dayFirstIntervalWorks() {
+        assertEquals(to10MinInterval(Instant.parse("2020-10-01T00:00:00Z")),
+                dayFirst10MinInterval(Instant.parse("2020-10-01T12:00:00Z")));
+    }
+
+    @Test
+    public void dayLastIntervalWorks() {
+        assertEquals(to10MinInterval(Instant.parse("2020-10-01T23:55:00Z")),
+                dayLast10MinInterval(Instant.parse("2020-10-01T12:00:00Z")));
+    }
+
+    @Test
+    public void utcLocalDateWorks() {
+        Instant now = Instant.now();
+        assertEquals(now.atZone(UTC).toLocalDate(), utcDateOf10MinInterval(to10MinInterval(now)));
+        assertEquals(Instant.EPOCH.atZone(UTC).toLocalDate(), utcDateOf10MinInterval(to10MinInterval(Instant.EPOCH)));
+        assertEquals(MAX_SUPPORTED_TIME.atZone(UTC).toLocalDate(), utcDateOf10MinInterval(to10MinInterval(MAX_SUPPORTED_TIME)));
+    }
+
+    @Test
+    public void secondsAreCorrectlyCalculatedFor24hInterval() {
+        assertEquals(0, startSecondOf24HourInterval(to24HourInterval(Instant.EPOCH)));
+        assertEquals(
+                MAX_SUPPORTED_TIME.getEpochSecond() - MAX_SUPPORTED_TIME.getEpochSecond() % (24*60*60),
+                startSecondOf24HourInterval(to24HourInterval(MAX_SUPPORTED_TIME)));
+    }
+}


### PR DESCRIPTION
As noted by static code checker, multiplications done with integers in a long-ranged value could overflow. In practice, that would be around 2038, but it's a simple fix. Also added basic tests for the class to verify the issue.

Fixes CodeQL notifications:
- https://github.com/THLfi/koronavilkku-backend/security/code-scanning/1?query=ref%3Arefs%2Fheads%2Ftrunk
- https://github.com/THLfi/koronavilkku-backend/security/code-scanning/2?query=ref%3Arefs%2Fheads%2Ftrunk