### PR TITLE
Implementation for more robust fetch

### DIFF
--- a/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyDao.java
+++ b/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyDao.java
@@ -70,6 +70,7 @@ public class DiagnosisKeyDao {
         return getAvailableIntervalsDirect();
     }
 
+    @Transactional
     public List<Integer> getAvailableIntervalsDirect() {
         LOG.info("Fetching available intervals");
         String sql = "select distinct submission_interval from en.diagnosis_key order by submission_interval";
@@ -85,6 +86,7 @@ public class DiagnosisKeyDao {
                 .stream().findFirst().orElseThrow(() -> new IllegalStateException("Count returned nothing."));
     }
 
+    @Transactional
     public List<TemporaryExposureKey> getIntervalKeys(int interval) {
         LOG.info("Fetching keys: {}", keyValue("interval", interval));
         String sql =
@@ -175,6 +177,7 @@ public class DiagnosisKeyDao {
         }
     }
 
+    @Transactional
     public void addInboundKeys(List<TemporaryExposureKey> keys, int interval) {
         if (!keys.isEmpty()) {
             batchInsert(interval, keys, Optional.of(new Timestamp(Instant.now().toEpochMilli())));

--- a/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyDao.java
+++ b/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/diagnosiskey/DiagnosisKeyDao.java
@@ -10,7 +10,6 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -131,11 +130,11 @@ public class DiagnosisKeyDao {
         String sql = "with batch as ( " +
                 "select key_data " +
                 "from en.diagnosis_key " +
-                "where sent_to_efgs is null and retry_count >= :min_retry_count and retry_count < :max_retry_count " +
+                "where efgs_sync is null and retry_count >= :min_retry_count and retry_count < :max_retry_count " +
                 "and consent_to_share " +
                 "order by key_data for update skip locked limit 5000 ) " +
                 "update en.diagnosis_key " +
-                "set sent_to_efgs = :timestamp, retry_count = retry_count + 1 " +
+                "set efgs_sync = :timestamp, retry_count = retry_count + 1 " +
                 "where key_data in (select key_data from batch) " +
                 "returning key_data, rolling_period, rolling_start_interval_number, transmission_risk_level, " +
                 "visited_countries, days_since_onset_of_symptoms, origin, consent_to_share";
@@ -158,7 +157,7 @@ public class DiagnosisKeyDao {
 
     @Transactional
     public void setNotSent(FederationOutboundOperation operation) {
-        String sql = "update en.diagnosis_key set sent_to_efgs = null where key_data = :key_data";
+        String sql = "update en.diagnosis_key set efgs_sync = null where key_data = :key_data";
         jdbcTemplate.batchUpdate(sql, operation.keys.stream().map(key -> Map.of("key_data", key.keyData))
                 .toArray((IntFunction<Map<String, String>[]>) Map[]::new)
         );
@@ -171,7 +170,7 @@ public class DiagnosisKeyDao {
         List<Timestamp> crashed = operationDao.getAndResolveCrashed(OUTBOUND);
 
         if (!crashed.isEmpty()) {
-            String sql = "update en.diagnosis_key set sent_to_efgs = null, retry_count = 0 where sent_to_efgs in (:timestamp)";
+            String sql = "update en.diagnosis_key set efgs_sync = null, retry_count = 0 where efgs_sync in (:timestamp)";
             jdbcTemplate.update(sql, Map.of("timestamp", crashed));
         }
     }
@@ -188,15 +187,15 @@ public class DiagnosisKeyDao {
         return jdbcTemplate.queryForObject(sql, Map.of("verification_id", verificationId), String.class);
     }
 
-    private void batchInsert(int interval, List<TemporaryExposureKey> newKeys, Optional<Timestamp> sentToEfgs) {
+    private void batchInsert(int interval, List<TemporaryExposureKey> newKeys, Optional<Timestamp> efgsSync) {
         String sql = "insert into " +
                 "en.diagnosis_key (key_data, rolling_period, rolling_start_interval_number, transmission_risk_level, " +
-                "submission_interval, origin, visited_countries, days_since_onset_of_symptoms, consent_to_share, sent_to_efgs) " +
+                "submission_interval, origin, visited_countries, days_since_onset_of_symptoms, consent_to_share, efgs_sync) " +
                 "values (:key_data, :rolling_period, :rolling_start_interval_number, :transmission_risk_level, " +
-                ":submission_interval, :origin, :visited_countries, :days_since_onset_of_symptoms, :consent_to_share, :sent_to_efgs) " +
+                ":submission_interval, :origin, :visited_countries, :days_since_onset_of_symptoms, :consent_to_share, :efgs_sync) " +
                 "on conflict do nothing";
         Map<String, Object>[] params = newKeys.stream()
-                .map(key -> createParamsMap(interval, key, sentToEfgs))
+                .map(key -> createParamsMap(interval, key, efgsSync))
                 .toArray((IntFunction<Map<String, Object>[]>) Map[]::new);
         jdbcTemplate.batchUpdate(sql, params);
     }
@@ -233,7 +232,7 @@ public class DiagnosisKeyDao {
         );
     }
 
-    private Map<String, Object> createParamsMap(int interval, TemporaryExposureKey key, Optional<Timestamp> sentToEfgs) {
+    private Map<String, Object> createParamsMap(int interval, TemporaryExposureKey key, Optional<Timestamp> efgsSync) {
         Map<String, Object> params = new HashMap<>();
         params.put("key_data", key.keyData);
         params.put("rolling_period", key.rollingPeriod);
@@ -244,7 +243,7 @@ public class DiagnosisKeyDao {
         params.put("visited_countries", key.visitedCountries.toArray(new String[0]));
         params.put("consent_to_share", key.consentToShareWithEfgs);
         params.put("days_since_onset_of_symptoms", key.daysSinceOnsetOfSymptoms.orElse(null));
-        params.put("sent_to_efgs", sentToEfgs.orElse(null));
+        params.put("efgs_sync", efgsSync.orElse(null));
         return params;
     }
 }

--- a/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/efgs/CallbackController.java
+++ b/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/efgs/CallbackController.java
@@ -19,16 +19,16 @@ public class CallbackController {
 
     private static final Logger LOG = LoggerFactory.getLogger(CallbackController.class);
 
-    private final FederationGatewayService federationGatewayService;
+    private final FederationGatewaySyncService federationGatewaySyncService;
 
-    public CallbackController(FederationGatewayService federationGatewayService) {
-        this.federationGatewayService = federationGatewayService;
+    public CallbackController(FederationGatewaySyncService federationGatewaySyncService) {
+        this.federationGatewaySyncService = federationGatewaySyncService;
     }
 
     @GetMapping("/callback")
     public void triggerCallback(@RequestParam("batchTag") String batchTag, @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         LOG.info("Import from efgs triggered by callback {} {}.", keyValue("batchTag", batchTag), keyValue("date", date.toString()));
-        federationGatewayService.startInbound(date, Optional.of(batchTag));
+        federationGatewaySyncService.startInbound(date, Optional.of(batchTag));
         LOG.info("Import from efgs triggered by callback finished.");
     }
 }

--- a/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/efgs/FederationGatewaySyncProcessor.java
+++ b/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/efgs/FederationGatewaySyncProcessor.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.Optional;
@@ -17,36 +16,43 @@ import static net.logstash.logback.argument.StructuredArguments.keyValue;
 public class FederationGatewaySyncProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(FederationGatewaySyncProcessor.class);
+    private LocalDate lastInboundSyncFromEfgs;
 
-    private final FederationGatewayService federationGatewayService;
+    private final FederationGatewaySyncService federationGatewaySyncService;
 
-    public FederationGatewaySyncProcessor(FederationGatewayService federationGatewayService) {
-        this.federationGatewayService = federationGatewayService;
+    public FederationGatewaySyncProcessor(FederationGatewaySyncService federationGatewaySyncService) {
+        this.federationGatewaySyncService = federationGatewaySyncService;
+        this.lastInboundSyncFromEfgs = LocalDate.now(ZoneOffset.UTC);
     }
 
     @Scheduled(initialDelayString = "${covid19.federation-gateway.upload-interval}",
             fixedRateString = "${covid19.federation-gateway.upload-interval}")
     private void runExportToEfgs() {
         LOG.info("Starting scheduled export to efgs.");
-        Set<Long> operationIds = federationGatewayService.startOutbound(false);
+        Set<Long> operationIds = federationGatewaySyncService.startOutbound(false);
         LOG.info("Scheduled export to efgs finished. {}", keyValue("operationId", operationIds));
     }
 
     @Scheduled(initialDelayString = "${covid19.federation-gateway.download-interval}",
             fixedRateString = "${covid19.federation-gateway.download-interval}")
     private void runImportFromEfgs() {
-        LOG.info("Starting scheduled import from efgs.");
-        federationGatewayService.startInbound(LocalDate.now(ZoneOffset.UTC), Optional.empty());
-        LOG.info("Scheduled import from efgs finished.");
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+
+        if (today.isAfter(lastInboundSyncFromEfgs)) {
+            LOG.info("Starting scheduled import from efgs.");
+            federationGatewaySyncService.startInbound(lastInboundSyncFromEfgs, Optional.empty());
+            lastInboundSyncFromEfgs = today;
+            LOG.info("Scheduled import from efgs finished.");
+        }
     }
 
     @Scheduled(initialDelayString = "${covid19.federation-gateway.error-handling-interval}",
             fixedRateString = "${covid19.federation-gateway.error-handling-interval}")
     private void runErrorHandling() {
         LOG.info("Starting scheduled efgs error handling.");
-        federationGatewayService.resolveCrash();
-        federationGatewayService.startOutbound(true);
-        federationGatewayService.startInboundRetry(LocalDate.now(ZoneOffset.UTC).minusDays(1));
+        federationGatewaySyncService.resolveCrash();
+        federationGatewaySyncService.startOutbound(true);
+        federationGatewaySyncService.startInboundRetry(lastInboundSyncFromEfgs);
         LOG.info("Scheduled efgs error handling finished.");
     }
 }

--- a/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/efgs/FederationGatewaySyncProcessor.java
+++ b/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/efgs/FederationGatewaySyncProcessor.java
@@ -17,7 +17,7 @@ import static net.logstash.logback.argument.StructuredArguments.keyValue;
 public class FederationGatewaySyncProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(FederationGatewaySyncProcessor.class);
-    private AtomicReference<LocalDate> lastInboundSyncFromEfgs;
+    private final AtomicReference<LocalDate> lastInboundSyncFromEfgs;
 
     private final FederationGatewaySyncService federationGatewaySyncService;
 

--- a/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/efgs/OperationDao.java
+++ b/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/efgs/OperationDao.java
@@ -66,7 +66,8 @@ public class OperationDao {
                 "keys_count_500", keysCount500,
                 "updated_at", new Timestamp(Instant.now().toEpochMilli())
         )) == 1;
-        LOG.info("Efgs sync finished. {} {} {}",
+        LOG.info("Efgs sync finished. {} {} {} {}",
+                keyValue("success", success),
                 keyValue("operationId", operation.operationId),
                 keyValue("batchTag", operation.batchTag),
                 keyValue("keys", keysCountTotal));

--- a/exposure-notification/src/main/resources/application.yml
+++ b/exposure-notification/src/main/resources/application.yml
@@ -84,12 +84,12 @@ covid19:
   publish-token:
     url: "${EN_PT_URL:}"
   federation-gateway:
-    url-template: https://test-efgs-ws.tech.ec.europa.eu/diagnosiskeys/{operation}/{variable}
+    url-template: "${EN_EFGS_URL:https://test-efgs-ws.tech.ec.europa.eu/diagnosiskeys/{operation}/{variable}}"
     rest-client:
       client-key-store:
         alias: efgs
     signing-key-store:
       key-alias: efgs-signing
-    upload-interval: PT23H
-    download-interval: PT24H
-    error-handling-interval: PT60M
+    upload-interval: PT12H
+    download-interval: PT10M
+    error-handling-interval: PT30M

--- a/exposure-notification/src/main/resources/db/migration/V03.02__alter_diagnosis_key.sql
+++ b/exposure-notification/src/main/resources/db/migration/V03.02__alter_diagnosis_key.sql
@@ -2,6 +2,6 @@ alter table en.diagnosis_key add origin varchar(2) not null default '';
 alter table en.diagnosis_key add visited_countries varchar(2)[] not null default '{}';
 alter table en.diagnosis_key add days_since_onset_of_symptoms int;
 alter table en.diagnosis_key add consent_to_share boolean not null default 'false';
-alter table en.diagnosis_key add sent_to_efgs timestamptz;
+alter table en.diagnosis_key add efgs_sync timestamptz;
 alter table en.diagnosis_key add retry_count int not null default 0;
 

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/TestKeyGenerator.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/diagnosiskey/TestKeyGenerator.java
@@ -43,7 +43,7 @@ public class TestKeyGenerator {
                 getRiskBucket(symptomsDays - ageDays),
                 dayFirst10MinInterval(Instant.now().minus(ageDays, ChronoUnit.DAYS)),
                 INTERVALS_10MIN_PER_24H,
-                Set.of(),
+                rand.nextBoolean() ? Set.of() : Set.of("DE","IT"),
                 Optional.of(dsos),
                 "FI",
                 consentToShare

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/efgs/CallbackControllerTest.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/efgs/CallbackControllerTest.java
@@ -21,7 +21,7 @@ public class CallbackControllerTest {
     private MockMvc mvc;
 
     @MockBean
-    private FederationGatewayService federationGatewayService;
+    private FederationGatewaySyncService federationGatewaySyncService;
 
 
     @Test

--- a/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/efgs/FederationServiceWithDaoTestIT.java
+++ b/exposure-notification/src/test/java/fi/thl/covid19/exposurenotification/efgs/FederationServiceWithDaoTestIT.java
@@ -65,7 +65,7 @@ public class FederationServiceWithDaoTestIT {
     NamedParameterJdbcTemplate jdbcTemplate;
 
     @Autowired
-    FederationGatewayService federationGatewayService;
+    FederationGatewaySyncService federationGatewaySyncService;
 
     @Autowired
     FederationGatewayBatchSigner signer;
@@ -101,12 +101,12 @@ public class FederationServiceWithDaoTestIT {
                         .headers(getDownloadResponseHeaders())
                         .body(serialize(transform(keys)))
                 );
-        federationGatewayService.startInbound(LocalDate.now(ZoneOffset.UTC), Optional.empty());
+        federationGatewaySyncService.startInbound(LocalDate.now(ZoneOffset.UTC), Optional.empty());
 
         List<TemporaryExposureKey> dbKeys = diagnosisKeyDao.getIntervalKeys(IntervalNumber.to24HourInterval(Instant.now()));
         assertTrue(keys.size() == dbKeys.size() && dbKeys.containsAll(keys) && keys.containsAll(dbKeys));
         operationDao.getAndResolveCrashed(INBOUND);
-        federationGatewayService.startInboundRetry(LocalDate.now(ZoneOffset.UTC));
+        federationGatewaySyncService.startInboundRetry(LocalDate.now(ZoneOffset.UTC));
         assertDownloadOperationStateIsCorrect(10);
     }
 
@@ -130,10 +130,10 @@ public class FederationServiceWithDaoTestIT {
                 );
         LocalDate date = LocalDate.now(ZoneOffset.UTC);
         try {
-            federationGatewayService.startInbound(date, Optional.of(TEST_TAG_NAME));
+            federationGatewaySyncService.startInbound(date, Optional.of(TEST_TAG_NAME));
         } catch (HttpServerErrorException e) {
             assertEquals(1, operationDao.getInboundErrorBatchTags(date).get(TEST_TAG_NAME));
-            federationGatewayService.startInboundRetry(date);
+            federationGatewaySyncService.startInboundRetry(date);
             assertFalse(operationDao.getInboundErrorBatchTags(date).containsKey(TEST_TAG_NAME));
         }
     }
@@ -149,14 +149,14 @@ public class FederationServiceWithDaoTestIT {
                 );
         LocalDate date = LocalDate.now(ZoneOffset.UTC);
         try {
-            federationGatewayService.startInbound(date, Optional.of(TEST_TAG_NAME));
+            federationGatewaySyncService.startInbound(date, Optional.of(TEST_TAG_NAME));
         } catch (HttpServerErrorException e) {
             assertEquals(1, operationDao.getInboundErrorBatchTags(date).get(TEST_TAG_NAME));
         }
         IntStream.rangeClosed(2, MAX_RETRY_COUNT).forEach(i ->
                 {
                     try {
-                        federationGatewayService.startInboundRetry(date);
+                        federationGatewaySyncService.startInboundRetry(date);
                     } catch (HttpServerErrorException e) {
                         if (i < MAX_RETRY_COUNT) {
                             assertEquals(i, operationDao.getInboundErrorBatchTags(date).get(TEST_TAG_NAME));
@@ -187,7 +187,7 @@ public class FederationServiceWithDaoTestIT {
                         .headers(getDownloadResponseHeaders())
                         .body(serialize(transform(keys)))
                 );
-        federationGatewayService.startInbound(LocalDate.now(ZoneOffset.UTC), Optional.empty());
+        federationGatewaySyncService.startInbound(LocalDate.now(ZoneOffset.UTC), Optional.empty());
 
         List<TemporaryExposureKey> dbKeys = diagnosisKeyDao.getIntervalKeys(IntervalNumber.to24HourInterval(Instant.now()));
         assertEquals(dbKeys.size(), keys.size());
@@ -210,7 +210,7 @@ public class FederationServiceWithDaoTestIT {
                         .body("")
                 );
         diagnosisKeyDao.addKeys(1, md5DigestAsHex("test".getBytes()), to24HourInterval(Instant.now()), keyGenerator.someKeys(5), 5);
-        Set<Long> operationIds = federationGatewayService.startOutbound(false);
+        Set<Long> operationIds = federationGatewaySyncService.startOutbound(false);
         assertFalse(operationIds.isEmpty());
         long operationId = operationIds.stream().findFirst().get();
         assertUploadOperationStateIsCorrect(operationId, 5, 5, 0, 0);
@@ -239,7 +239,7 @@ public class FederationServiceWithDaoTestIT {
                         .contentType(PROTOBUF_MEDIATYPE)
                         .body("")
                 );
-        Set<Long> operationIds = federationGatewayService.startOutbound(false);
+        Set<Long> operationIds = federationGatewaySyncService.startOutbound(false);
         assertFalse(operationIds.isEmpty());
         long operationId = operationIds.stream().findFirst().get();
         assertUploadOperationStateIsCorrect(operationId, 5, 2, 2, 1);
@@ -268,11 +268,11 @@ public class FederationServiceWithDaoTestIT {
                 to24HourInterval(Instant.now()), keyGenerator.someKeys(5), 5);
 
         try {
-            federationGatewayService.startOutbound(false);
+            federationGatewaySyncService.startOutbound(false);
         } catch (HttpServerErrorException e) {
             assertOperationErrorStateIsCorrect(OUTBOUND);
         }
-        Set<Long> operationIds = federationGatewayService.startOutbound(true);
+        Set<Long> operationIds = federationGatewaySyncService.startOutbound(true);
         assertUploadOperationErrorStateIsFinished(operationIds.stream().findFirst().get());
         assertEquals(1, getOutboundOperationsInError().size());
         assertTrue(diagnosisKeyDao.fetchAvailableKeysForEfgs(false).isEmpty());
@@ -310,7 +310,7 @@ public class FederationServiceWithDaoTestIT {
         diagnosisKeyDao.addKeys(1, md5DigestAsHex("test".getBytes()),
                 to24HourInterval(Instant.now()), keyGenerator.someKeys(10000), 10000);
 
-        Set<Long> operationIds = federationGatewayService.startOutbound(false);
+        Set<Long> operationIds = federationGatewaySyncService.startOutbound(false);
         assertFalse(operationIds.isEmpty());
         assertEquals(2, operationIds.size());
         operationIds.forEach(id -> assertUploadOperationStateIsCorrect(id, 5000, 5000, 0, 0));
@@ -357,7 +357,7 @@ public class FederationServiceWithDaoTestIT {
 
     private void doOutBound() {
         try {
-            federationGatewayService.startOutbound(false);
+            federationGatewaySyncService.startOutbound(false);
         } catch (HttpServerErrorException e) {
             assertOperationErrorStateIsCorrect(OUTBOUND);
             assertTrue(diagnosisKeyDao.fetchAvailableKeysForEfgs(false).isEmpty());
@@ -366,7 +366,7 @@ public class FederationServiceWithDaoTestIT {
 
     private void doOutBoundRetry(int i) {
         try {
-            federationGatewayService.startOutbound(true);
+            federationGatewaySyncService.startOutbound(true);
         } catch (HttpServerErrorException e) {
             assertOperationErrorStateIsCorrect(OUTBOUND);
             assertTrue(diagnosisKeyDao.fetchAvailableKeysForEfgs(false).isEmpty());
@@ -457,7 +457,7 @@ public class FederationServiceWithDaoTestIT {
         Timestamp timestamp = new Timestamp(Instant.now().minus(Duration.ofMinutes(STALLED_MIN_AGE_IN_MINUTES)).toEpochMilli());
         String sql1 = "update en.efgs_operation set updated_at = :updated_at";
         jdbcTemplate.update(sql1, Map.of("updated_at", timestamp));
-        String sql2 = "update en.diagnosis_key set sent_to_efgs = :sent_to_efgs";
-        jdbcTemplate.update(sql2, Map.of("sent_to_efgs", timestamp));
+        String sql2 = "update en.diagnosis_key set efgs_sync = :efgs_sync";
+        jdbcTemplate.update(sql2, Map.of("efgs_sync", timestamp));
     }
 }


### PR DESCRIPTION
Implementation for more robust fetch, until we get callback available and as another option for download

- tries to prevent unnecessary rest-calls
- scheduling support to fetch yesterday's keys after utc midnight
- some refactoring + tuning
