### PR TITLE
Synchronize multithreaded file reads by using a cache -> IO once and avoid multi-locking

### DIFF
--- a/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/batch/BatchIntervals.java
+++ b/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/batch/BatchIntervals.java
@@ -14,10 +14,10 @@ public class BatchIntervals {
     private static final Duration DISTRIBUTION_DELAY = Duration.ofHours(1);
 
     private static final int DAYS_TO_DISTRIBUTE_BATCHES = 14;
-    private static final int DAYS_TO_KEEP_BATCHES = DAYS_TO_DISTRIBUTE_BATCHES + 1;
+    public static final int DAYS_TO_KEEP_BATCHES = DAYS_TO_DISTRIBUTE_BATCHES + 1;
     public static final int DAILY_BATCHES_COUNT = 6;
     private static final int V2_INTERVALS_TO_DISTRIBUTE_BATCHES = DAYS_TO_DISTRIBUTE_BATCHES * DAILY_BATCHES_COUNT;
-    private static final int V2_INTERVALS_TO_KEEP_BATCHES = DAYS_TO_KEEP_BATCHES * DAILY_BATCHES_COUNT;
+    public static final int V2_INTERVALS_TO_KEEP_BATCHES = DAYS_TO_KEEP_BATCHES * DAILY_BATCHES_COUNT;
 
     public final int current;
     public final int first;

--- a/exposure-notification/src/main/resources/application.yml
+++ b/exposure-notification/src/main/resources/application.yml
@@ -75,6 +75,7 @@ covid19:
     data-cache:
       enabled: true
       status-duration: PT5M
+      file-duration: PT10S
   maintenance:
     # How often is maintenance-check done
     interval: PT15M


### PR DESCRIPTION
Solves the same issue as https://github.com/THLfi/koronavilkku-backend/pull/64 but cleaner