### PR TITLE
DEPENDENCY_UPGRADE:

### DIFF
--- a/exposure-notification/pom.xml
+++ b/exposure-notification/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.9</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -21,7 +21,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
-        <cache2k-version>2.0.0.Final</cache2k-version>
+        <cache2k-version>2.4.1.Final</cache2k-version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,11 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>6.6</version>
+            <version>7.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
@@ -78,7 +82,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.24</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -151,9 +154,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.0.5</version>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>5.0.0</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>
@@ -182,7 +185,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>6.5.2</version>
+                        <version>6.5.3</version>
                         <configuration>
                             <failBuildOnCVSS>0</failBuildOnCVSS>
                             <suppressionFiles>

--- a/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/batch/BatchFileFactory.java
+++ b/exposure-notification/src/main/java/fi/thl/covid19/exposurenotification/batch/BatchFileFactory.java
@@ -2,7 +2,7 @@ package fi.thl.covid19.exposurenotification.batch;
 
 import com.google.protobuf.ByteString;
 import fi.thl.covid19.proto.*;
-import net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/publish-token/pom.xml
+++ b/publish-token/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.9</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -39,7 +39,11 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>6.6</version>
+            <version>7.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
@@ -52,7 +56,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.24</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -96,9 +99,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.0.5</version>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>5.0.0</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>
@@ -126,7 +129,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>6.5.2</version>
+                        <version>6.5.3</version>
                         <configuration>
                             <failBuildOnCVSS>0</failBuildOnCVSS>
                             <suppressionFiles>

--- a/publish-token/src/test/java/fi/thl/covid19/publishtoken/PublishTokenDaoIT.java
+++ b/publish-token/src/test/java/fi/thl/covid19/publishtoken/PublishTokenDaoIT.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import static fi.thl.covid19.publishtoken.Validation.SERVICE_NAME_MAX_LENGTH;
 import static fi.thl.covid19.publishtoken.Validation.USER_NAME_MAX_LENGTH;
 import static java.time.temporal.ChronoUnit.HOURS;
-import static net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils.repeat;
+import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest

--- a/publish-token/src/test/java/fi/thl/covid19/publishtoken/ValidationTest.java
+++ b/publish-token/src/test/java/fi/thl/covid19/publishtoken/ValidationTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static fi.thl.covid19.publishtoken.Validation.SERVICE_NAME_MAX_LENGTH;
 import static fi.thl.covid19.publishtoken.Validation.USER_NAME_MAX_LENGTH;
-import static net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils.repeat;
+import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 


### PR DESCRIPTION
    * spring boot to version 2.5.9
    * change postgresql to use version from spring-boot
    * git-commit-id-plugin relocation (no functional changes based on release notes)
    * cache2k to version 2.4.1.Final
    * logstash-logback-encoder to version 7.0.1
    * introduced commons-lang3 as dependency and use it in imports instead of version provided by earlier logstash-logback-encoder
    * owasp-dependency-check to version 6.5.3